### PR TITLE
docs: add `Past Maintainer(s)`

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,13 @@ The currently active maintainer(s) of this project.
 <!-- UPDATE -->
 - [NAME](https://github.com/GITHUB_USERNAME)
 
+### Past Maintainer(s)
+
+Previous maintainer(s) of this project.
+
+<!-- UPDATE -->
+- [NAME](https://github.com/GITHUB_USERNAME)
+
 ### Creator(s)
 
 Honoring the original creator(s) and ideator(s) of this project.


### PR DESCRIPTION
# Description
Added `Past Maintainer(s)` to honor the previously active maintainers of the project.
